### PR TITLE
fix: improve release notes generation logic to handle first release case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check npm version compatibility
+        uses: joshjohanning/npm-version-check-action@v1
+
+      # TODO: Enable linting when rules are added
+      # - name: Run linting
+      #   run: npm run lint
+
+      # TODO: Enable formatting when rules are added
+      # - name: Run formatting check
+      #   run: npm run format:check
+
+      # TODO: Enable when tests are added
+      # - name: Run tests
+      #   run: npm test
+
+      - name: Package the action
+        run: npm run package
+
+      - name: Validate action.yml
+        run: |
+          # Basic validation that action.yml is valid YAML
+          if command -v yq &> /dev/null; then
+            yq eval '.' action.yml > /dev/null
+          else
+            # Fallback to python yaml check
+            python -c "import yaml; yaml.safe_load(open('action.yml'))"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Publish GitHub Action
 
+[![CI](https://github.com/joshjohanning/publish-github-action/actions/workflows/ci.yml/badge.svg)](https://github.com/joshjohanning/publish-github-action/actions/workflows/ci.yml)
 [![Publish GitHub Action](https://github.com/joshjohanning/publish-github-action/actions/workflows/publish.yml/badge.svg?branch=main&event=push)](https://github.com/joshjohanning/publish-github-action/actions/workflows/publish.yml)
 
 This action creates a release branch for your GitHub Actions which will be automatically tagged and released. The release version can be  defined in `package.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "description": "Publish your GitHub Action",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "npx tsc",
     "package": "npm run build && npx @vercel/ncc build lib/main.js -o dist",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "all": "npm run build && npm run test && npm run package"
   },
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,21 +80,26 @@ async function run() {
 
     // Generate release notes
     let releaseNotes = '';
-    if (previousTag) {
-      try {
-        const generatedNotes = await octokit.request('POST /repos/{owner}/{repo}/releases/generate-notes', {
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          tag_name: version,
-          previous_tag_name: previousTag
-        });
-        releaseNotes = generatedNotes.data.body;
-        console.log('Generated release notes from', previousTag, 'to', version);
-      } catch (error) {
-        console.log('Could not generate release notes:', (error as Error).message);
+    try {
+      const requestData: any = {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        tag_name: version
+      };
+      
+      // Only add previous_tag_name if we found one
+      if (previousTag) {
+        requestData.previous_tag_name = previousTag;
+        console.log('Generating release notes from', previousTag, 'to', version);
+      } else {
+        console.log('Generating release notes for first release', version);
       }
-    } else {
-      console.log('No previous semver release found, creating release without generated notes');
+
+      const generatedNotes = await octokit.request('POST /repos/{owner}/{repo}/releases/generate-notes', requestData);
+      releaseNotes = generatedNotes.data.body;
+      console.log('Successfully generated release notes');
+    } catch (error) {
+      console.log('Could not generate release notes:', (error as Error).message);
     }
 
     await octokit.rest.repos.createRelease({


### PR DESCRIPTION
Release notes generation improvements:
* Updated the logic in `src/main.ts` to handle the case where there is no previous tag, ensuring that release notes are generated appropriately for both first-time and subsequent releases. Added informative logging for both scenarios.

Developer workflow enhancements:
* Added a new `all` script to `package.json` that runs build, test, and package steps in sequence, streamlining the development process.

Other:
* Bumped the package version from `1.4.2` to `1.4.3` in `package.json`.