### PR TITLE
feat: add option to commit dist folder in GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         npm_package_command: npm run package
         commit_node_modules: false
+        commit_dist_folder: true # defaults to true
         publish_minor_version: false
         publish_release_branch: false
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Change to true to commit node_modules folder'
     default: 'false'
     required: false
+  commit_dist_folder:
+    description: 'Change to true to commit dist folder'
+    default: 'true'
+    required: false
   publish_minor_version:
     description: 'Change to true to publish minor version'
     default: 'false'

--- a/dist/index.js
+++ b/dist/index.js
@@ -57,6 +57,7 @@ const semver = __nccwpck_require__(2088);
 const githubToken = core.getInput('github_token', { required: true });
 const npmPackageCommand = core.getInput('npm_package_command', { required: false });
 const commitNodeModules = core.getInput('commit_node_modules', { required: false });
+const commitDistFolder = core.getInput('commit_dist_folder', { required: false });
 const publishMinorVersion = core.getInput('publish_minor_version', { required: false });
 const publishReleaseVersion = core.getInput('publish_release_branch', { required: false });
 const context = github.context;
@@ -85,6 +86,9 @@ function run() {
             }
             if (commitNodeModules === 'true') {
                 yield exec.exec('git add -f node_modules');
+            }
+            if (commitDistFolder === 'true') {
+                yield exec.exec('git add -f dist');
             }
             yield exec.exec('git rm -r .github');
             yield exec.exec('git commit -a -m "prod dependencies"');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "description": "Publish your GitHub Action",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ async function run() {
     if (commitDistFolder === 'true') {
         await exec.exec('git add -f dist');
     }
-    
+
     await exec.exec('git rm -r .github');
     await exec.exec('git commit -a -m "prod dependencies"');
     if (publishReleaseVersion === 'true') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ const semver = require('semver');
 const githubToken = core.getInput('github_token', { required: true });
 const npmPackageCommand = core.getInput('npm_package_command', { required: false });
 const commitNodeModules = core.getInput('commit_node_modules', { required: false });
+const commitDistFolder = core.getInput('commit_dist_folder', { required: false });
 const publishMinorVersion = core.getInput('publish_minor_version', { required: false });
 const publishReleaseVersion = core.getInput('publish_release_branch', { required: false });
 const context = github.context;
@@ -39,6 +40,11 @@ async function run() {
     if (commitNodeModules === 'true') {
         await exec.exec('git add -f node_modules');
     }
+
+    if (commitDistFolder === 'true') {
+        await exec.exec('git add -f dist');
+    }
+    
     await exec.exec('git rm -r .github');
     await exec.exec('git commit -a -m "prod dependencies"');
     if (publishReleaseVersion === 'true') {


### PR DESCRIPTION
**New feature: Commit `dist` folder**

* Added a new input parameter `commit_dist_folder` to `action.yml` to allow users to specify whether to commit the `dist` folder (defaults to true).
* Updated the workflow in `src/main.ts` to check the value of `commitDistFolder` and add the `dist` folder to the commit if enabled. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR9) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR43-R47)
* Updated the documentation in `README.md` to document the new `commit_dist_folder` option.