### PR TITLE
fix: replace npm install with npm ci for production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "private": true,
   "description": "Publish your GitHub Action",

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export async function run() {
     }
 
     await exec.exec('git rm -r .github');
-    await exec.exec('git commit -a -m "prod dependencies"');
+    await exec.exec('git commit -a -m "chore: prod dependencies"');
 
     if (publishReleaseVersion === 'true') {
       await exec.exec('git', ['push', 'origin', branchName]);

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export async function run() {
     }
 
     await exec.exec('git', ['checkout', '-b', branchName]);
-    await exec.exec('npm install --production');
+    await exec.exec('npm ci --production');
     await exec.exec('git config --global user.email "github-actions[bot]@users.noreply.github.com"');
     await exec.exec('git config --global user.name "github-actions[bot]"');
     await exec.exec('git', [


### PR DESCRIPTION
Dependency management improvements:

* Changed the dependency installation command from `npm install --production` to `npm ci --production` in `src/index.js` to ensure a clean and reproducible install using the lockfile.

Commit message standardization:

* Updated the commit message from "prod dependencies" to "chore: prod dependencies" in `src/index.js` for better clarity and adherence to conventional commit standards.

Version bump:

* Incremented the package version from `2.0.0` to `2.0.1` in `package.json` to reflect these changes.