### PR TITLE
chore: update commit message for production release preparation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "private": true,
   "description": "Publish your GitHub Action",

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export async function run() {
     }
 
     await exec.exec('git rm -r .github');
-    await exec.exec('git commit -a -m "chore: prod dependencies"');
+    await exec.exec('git', ['commit', '-a', '-m', `chore: prepare ${version} release`]);
 
     if (publishReleaseVersion === 'true') {
       await exec.exec('git', ['push', 'origin', branchName]);


### PR DESCRIPTION
* Versioning:
  * Updated the package version in `package.json` from `2.0.1` to `2.0.2` to reflect the latest changes.
* Release process:
  * Improved the release commit message in `src/index.js` to include the version number, making it clearer when preparing a release (e.g., "chore: prepare 2.0.2 release" instead of the previous generic message).