### PR TITLE
fix: update npm ci command to omit dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "private": true,
   "description": "Publish your GitHub Action",

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export async function run() {
     }
 
     await exec.exec('git', ['checkout', '-b', branchName]);
-    await exec.exec('npm ci --production');
+    await exec.exec('npm', ['ci', '--omit=dev']);
     await exec.exec('git config --global user.email "github-actions[bot]@users.noreply.github.com"');
     await exec.exec('git config --global user.name "github-actions[bot]"');
     await exec.exec('git', [


### PR DESCRIPTION
- Version update:
  * Bumped the package version from `2.0.2` to `2.0.3` in `package.json` to reflect the new changes.

- Workflow improvement:
  * Updated the npm install command in `src/index.js` to use `npm ci --omit=dev` instead of `npm ci --production`, aligning with modern npm best practices for omitting development dependencies.