### PR TITLE
ci: enable creation of draft releases in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,4 @@ jobs:
           commit_node_modules: false
           publish_minor_version: false
           publish_release_branch: false
+          create_release_as_draft: true

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package
           commit_node_modules: false
-          commit_dist_folder: true # defaults to true
+          commit_dist_folder: false # defaults to true
           publish_minor_version: false
           publish_release_branch: false
+          create_release_as_draft: false
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package
           commit_node_modules: false
-          commit_dist_folder: false # defaults to true
+          commit_dist_folder: true
           publish_minor_version: false
           publish_release_branch: false
           create_release_as_draft: false


### PR DESCRIPTION
This pull request introduces a configuration change to the publishing workflow. The main update is enabling the creation of releases as drafts, which allows for review before the release is finalized.