### PR TITLE
feat!: upgrade GitHub Actions runtime from node20 to node24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,8 @@ const { functionToTest } = await import('../src/index.js');
 
 ### Node Runtime
 
-- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node24`) for `runs.using`
+- Only use Node.js runtimes officially supported by GitHub Actions (see [GitHub Actions documentation](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions) for current supported versions)
+- Use the same Node.js runtime version configured in this repo's `action.yml` for `runs.using`
 - When updating Node.js support, update `runs.using` in `action.yml`, the `engines.node` range in `package.json`, and CI/test matrices together to stay consistent
 
 ### Input Handling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ const { functionToTest } = await import('../src/index.js');
 
 ### Node Runtime
 
-- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node20`) for `runs.using`
+- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node24`) for `runs.using`
 - When updating Node.js support, update `runs.using` in `action.yml`, the `engines.node` range in `package.json`, and CI/test matrices together to stay consistent
 
 ### Input Handling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: joshjohanning/publish-github-action@v2
+      - uses: joshjohanning/publish-github-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: joshjohanning/publish-github-action@v3
+      - uses: joshjohanning/publish-github-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This action creates a release branch for your GitHub Actions which will be autom
 
 Based on the [tgymnich/publish-github-action](https://github.com/tgymnich/publish-github-action) action, but I wanted further customization and control over the release process (i.e.: adding `ncc` output and not committing `node_modules` directory).
 
+## What's new
+
+Please refer to the [release page](https://github.com/joshjohanning/publish-github-action/releases) for the latest release notes.
+
 ## Features
 
 - 🔐 **Verified Commits** - Uses GitHub API to create verified commits (when `commit_node_modules` is `false`)
@@ -81,7 +85,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: install ncc
         run: npm i -g @vercel/ncc
-      - uses: joshjohanning/publish-github-action@v2
+      - uses: joshjohanning/publish-github-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: install ncc
         run: npm i -g @vercel/ncc
       - uses: joshjohanning/publish-github-action@v3

--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-github-action",
-  "version": "2.3.5",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-github-action",
-      "version": "2.3.5",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",
@@ -28,7 +28,7 @@
         "prettier": "^3.8.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-github-action",
-  "version": "2.3.5",
+  "version": "3.0.0",
   "type": "module",
   "private": true,
   "description": "Publish your GitHub Action",
@@ -8,7 +8,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "bundle": "npm run format:write && npm run package",


### PR DESCRIPTION
## Summary

Upgrade the GitHub Actions runtime from `node20` to `node24` since `node20` is now deprecated.

## Changes

- **action.yml**: Updated `runs.using` from `node20` to `node24`
- **package.json**: Bumped version from `2.3.5` to `3.0.0`, updated `engines.node` from `>=20` to `>=24`
- **.github/workflows/ci.yml**: Updated `node-version` from `20` to `24`
- **.github/workflows/publish.yml**: Updated self-reference from `@v2` to `@v3`
- **.github/copilot-instructions.md**: Updated node runtime reference
- **README.md**: Updated usage examples from `@v2` to `@v3`, added "What's new" section
- **package-lock.json**: Synced with updated package.json

## ⚠️ Breaking Changes

- **Runtime**: GitHub Actions runtime changed from `node20` to `node24`
- **Major version bump**: `v2` → `v3` — users must update their workflow references from `@v2` to `@v3`