### PR TITLE
ci: update npm-version-check-action to v2 and publish-github-action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           fi
 
       - name: Check npm version compatibility
-        uses: joshjohanning/npm-version-check-action@v1
+        uses: joshjohanning/npm-version-check-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: joshjohanning/publish-github-action@v2
+      - uses: joshjohanning/publish-github-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package


### PR DESCRIPTION
## Summary

Update CI dependency references since both actions have been upgraded to node24.

- `npm-version-check-action`: `@v1` → `@v2`
- `publish-github-action`: `@v2` → `@v3` (self-reference in publish workflow)